### PR TITLE
fix: return 409 Conflict for duplicate permission creation

### DIFF
--- a/internal/services/permissions/create.go
+++ b/internal/services/permissions/create.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Kisanlink/aaa-service/internal/entities/models"
+	"github.com/Kisanlink/aaa-service/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -27,7 +28,7 @@ func (s *Service) CreatePermission(ctx context.Context, permission *models.Permi
 		s.logger.Warn("Permission already exists",
 			zap.String("name", permission.Name),
 			zap.String("existing_id", existing.ID))
-		return fmt.Errorf("permission with name '%s' already exists", permission.Name)
+		return errors.NewConflictError(fmt.Sprintf("permission with name '%s' already exists", permission.Name))
 	}
 
 	// Verify resource exists if provided


### PR DESCRIPTION
- Updated permission service to return ConflictError instead of generic error for duplicate permissions
- Updated permission handler to detect ConflictError and return 409 status code
- Added 409 response documentation to Swagger annotations

This provides proper HTTP status code (409 Conflict) instead of 500 Internal Server Error when attempting to create a permission that already exists.